### PR TITLE
[bugfix] Update verify popup in homepage to wrap on overflow and copy text

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -180,6 +180,10 @@ export default function AlertDialog(props: PopupProps) {
     });
   };
 
+  const verificationText = `@npub1teawtzxh6y02cnp9jphxm2q8u6xxfx85nguwg6ftuksgjctvavvqnsgq5u Verifying My Public Key: "${
+    twitterHandle || 'Your twitter handle here'
+  }"`
+
   return (
     <>
       <span onClick={handleClickOpen} className="cursor-pointer">
@@ -231,10 +235,8 @@ export default function AlertDialog(props: PopupProps) {
               format: {'\n'}
             </Typography>
             <div className="copyToClipboardContainer">
-              <code>{`@npub1teawtzxh6y02cnp9jphxm2q8u6xxfx85nguwg6ftuksgjctvavvqnsgq5u Verifying My Public Key: "${
-                twitterHandle || 'Your twitter handle here'
-              }"`}</code>
-              <button>Copy to clipboard</button>
+              <code>{verificationText}</code>
+              <button onClick={() => navigator.clipboard.writeText(verificationText)}>Copy to clipboard</button>
             </div>
             <p>Twitter screen name</p>
             <TextField

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -356,6 +356,7 @@ export default function AlertDialog(props: PopupProps) {
 
           .copyToClipboardContainer code {
             flex: 1;
+            overflow-wrap: anywhere;
           }
           p {
             font-weight: 700;


### PR DESCRIPTION
## Problem

If you go to the [nostr.directory homepage](https://nostr.directory) right now and click on the verification popup, there are two issues:
1. The verification text overflows which is unfriendly for mobile clients or smaller window sizes
2. The `copy to clipboard` button doesn't do anything

See screenshot below:
<img width="717" alt="CleanShot 2023-03-06 at 21 24 24@2x" src="https://user-images.githubusercontent.com/5943807/223328294-8dab621d-775e-48ac-a053-7ddda0746a5f.png">

## Proposed Fix

Adding `overflow-wrap` property to the code block so line breaks can be inserted for a better visual experience, and an `onclick` method to the copy button so the verification text can be copied to the user's clipboard. 

Tested by running the changes with gitpod 
<img width="718" alt="CleanShot 2023-03-06 at 21 26 53@2x" src="https://user-images.githubusercontent.com/5943807/223328632-b1bfb131-38b0-488d-890c-a261a16203c1.png">

Relatively small change so I skipped making an issue, feedback/review welcome! :)